### PR TITLE
Add severity key in Phan converter

### DIFF
--- a/src/Phan/PhanConvertToSubset.php
+++ b/src/Phan/PhanConvertToSubset.php
@@ -9,6 +9,12 @@ use BeechIt\JsonToCodeClimateSubsetConverter\Exceptions\InvalidJsonException;
 
 final class PhanConvertToSubset extends AbstractConverter
 {
+    private const SEVERITY_LEVELS = [
+        0 => 'info',
+        5 => 'minor',
+        10 => 'critical'
+    ];
+    
     public function convertToSubset(): void
     {
         try {
@@ -22,6 +28,7 @@ final class PhanConvertToSubset extends AbstractConverter
                         $node->location->path,
                         $node->location->lines->begin
                     ),
+                    'severity' => self::SEVERITY_LEVELS[$node->severity] ?? null,
                     'location' => [
                         'path' => $node->location->path,
                         'lines' => [


### PR DESCRIPTION
Reported errors by Phan are not recognized by Gitlab Code Quality due to missing severity key in the generated Code Climate nodes.

See https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool for a description of the required elements